### PR TITLE
Refactor/improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
 tests/resources
-helpers/jquery*.js
+jquery*.js
 *tmp*.*
 *tmp*/

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -18,12 +18,12 @@ const skipBuiltinFunctions = ['Function', 'eval', 'Array', 'Object', 'fetch', 'X
 // Identifiers that shouldn't be touched since they're either session-based or resolve inconsisstently.
 const skipIdentifiers = [
 	'window', 'this', 'self', 'document', 'module', '$', 'jQuery', 'navigator', 'typeof', 'new', 'Date', 'Math',
-	'Promise', 'Error', 'fetch', 'XMLHttpRequest'
+	'Promise', 'Error', 'fetch', 'XMLHttpRequest', 'performance',
 ];
 
 // Properties that shouldn't be resolved since they're either based on context which can't be determined or resolve inconsistently.
 const skipProperties = [
-	'test', 'exec', 'match', 'length', 'freeze', 'call', 'apply', 'create', 'getTime',
+	'test', 'exec', 'match', 'length', 'freeze', 'call', 'apply', 'create', 'getTime', 'now',
 	'getMilliseconds', ...propertiesThatModifyContent,
 ];
 

--- a/src/modules/safe/consolidateNestedBlockStatements.js
+++ b/src/modules/safe/consolidateNestedBlockStatements.js
@@ -10,7 +10,18 @@ function consolidateNestedBlockStatements(arb) {
 		n.type === 'BlockStatement' &&
 		n.parentNode.type === 'BlockStatement');
 	for (const c of candidates) {
-		arb.markNode(c.parentNode, c);
+		if (c.parentNode.body?.length > 1) {
+			if (c.body.length === 1) arb.markNode(c, c.body[0]);
+			else {
+				const currentIdx = c.parentNode.body.indexOf(c);
+				const replacementNode = {
+					type: 'BlockStatement',
+					body: [...c.parentNode.body.slice(0, currentIdx), ...c.body, ...c.parentNode.body.slice(currentIdx + 1)],
+				};
+				arb.markNode(c.parentNode, replacementNode);
+			}
+		}
+		else arb.markNode(c.parentNode, c);
 	}
 	return arb;
 }

--- a/src/modules/utils/runLoop.js
+++ b/src/modules/utils/runLoop.js
@@ -17,23 +17,26 @@ function runLoop(script, funcs, maxIterations = defaultMaxIterations, logger = d
 	let scriptSnapshot = '';
 	let currentIteration = 0;
 	try {
+		let scriptHash = generateScriptHash(script);
+		let changesCounter = 0;
 		let arborist = new Arborist(generateFlatAST(script), logger.log);
 		while (scriptSnapshot !== script && currentIteration < maxIterations) {
 			const cycleStartTime = Date.now();
 			scriptSnapshot = script;
-			const scriptHash = generateScriptHash(script);
 			arborist.ast.forEach(n => n.scriptHash = scriptHash);   // Mark each node with the script hash to distinguish cache of different scripts.
-			let lastNumberOfChanges = 0;
-			// eslint-disable-next-line no-unused-vars
 			for (const func of funcs) {
 				const funcStartTime = +new Date();
 				try {
 					logger.log(`\t[!] Running ${func.name}...`, 1);
 					arborist = func(arborist);
-					const numberOfNewChanges = (Object.keys(arborist.markedForReplacement).length + arborist.markedForDeletion.length) || !arborist.ast[0].scriptHash;
-					if (numberOfNewChanges > lastNumberOfChanges) {
-						logger.log(`\t[+] ${func.name} committed ${numberOfNewChanges - lastNumberOfChanges} new changes!`);
-						lastNumberOfChanges = numberOfNewChanges;
+					// If the hash doesn't exist it means the Arborist was replaced
+					const numberOfNewChanges = ((Object.keys(arborist.markedForReplacement).length + arborist.markedForDeletion.length)) || +!arborist.ast[0].scriptHash;
+					if (numberOfNewChanges) {
+						changesCounter += numberOfNewChanges;
+						logger.log(`\t[+] ${func.name} committed ${numberOfNewChanges} new changes!`);
+						arborist.applyChanges();
+						scriptHash = generateScriptHash(script);
+						arborist.ast.forEach(n => n.scriptHash = scriptHash);
 					}
 				} catch (e) {
 					logger.error(`[-] Error in ${func.name} (iteration #${iterationsCounter}): ${e}\n${e.stack}`);
@@ -42,16 +45,13 @@ function runLoop(script, funcs, maxIterations = defaultMaxIterations, logger = d
 						`${((+new Date() - funcStartTime) / 1000).toFixed(3)} seconds`, 1);
 				}
 			}
-			const changesMade = arborist.applyChanges() || !arborist.ast[0].scriptHash;   // If the hash doesn't exist it means the Arborist was replaced
-			if (changesMade) {
-				script = generateCode(arborist.ast[0]);
-			}
 			++currentIteration;
 			++iterationsCounter;
 			logger.log(`[+] ==> Cycle ${iterationsCounter} completed in ${(Date.now() - cycleStartTime) / 1000} seconds` +
-				` with ${changesMade ? changesMade : 'no'} changes (${arborist.ast.length} nodes)`);
+				` with ${changesCounter ? changesCounter : 'no'} changes (${arborist.ast.length} nodes)`);
 			if (maxIterations) break;
 		}
+		if (changesCounter) script = generateCode(arborist.ast[0]);
 	} catch (e) {
 		logger.error(`[-] Error on loop #${iterationsCounter}: ${e}\n${e.stack}`);
 	}

--- a/src/utils/cleanScript.js
+++ b/src/utils/cleanScript.js
@@ -1,0 +1,10 @@
+/*
+ * Pass scripts through this tool to help compare pre- and post- deobfuscation
+ */
+const fs = require('node:fs');
+const {generateFlatAST, generateCode} = require('flast');
+
+const inFileName = process.argv[2];
+const outFileName = inFileName + '-clean.js';
+fs.writeFileSync(outFileName, generateCode(generateFlatAST(fs.readFileSync(inFileName, 'utf-8'))[0]));
+console.log(`[+] Created clean file - ${outFileName}`);

--- a/tests/modules-tests.js
+++ b/tests/modules-tests.js
@@ -11,6 +11,20 @@ module.exports = [
 	},
 	{
 		enabled: true,
+		name: 'consolidateNestedBlockStatements - TP-2',
+		func: __dirname + '/../src/modules/safe/consolidateNestedBlockStatements',
+		source: `if (a) {{do_a();}{do_b();}}`,
+		expected: `if (a) {\n  do_a();\n  do_b();\n}`,
+	},
+	{
+		enabled: true,
+		name: 'consolidateNestedBlockStatements - TP-3',
+		func: __dirname + '/../src/modules/safe/consolidateNestedBlockStatements',
+		source: `if (a) {{do_a();}{do_b(); do_c();}{do_d();}}`,
+		expected: `if (a) {\n  do_a();\n  do_b();\n  do_c();\n  do_d();\n}`,
+	},
+	{
+		enabled: true,
 		name: 'normalizeComputed - TP-1',
 		func: __dirname + '/../src/modules/safe/normalizeComputed',
 		source: `hello['world'][0]['%32']['valid']`,

--- a/tests/testRestringer.js
+++ b/tests/testRestringer.js
@@ -7,7 +7,8 @@ const availableTests = {
 console.time('\nAll tests completed in');
 let exception = '';
 for (const [testName, testFile] of Object.entries(availableTests)) {
-	console.log(`\n----------> ${testName} <----------`);
+	const padLength = Math.floor((120 - testName.length - 4) / 2);
+	console.log(`\n${'>'.padStart(padLength, '-')} ${testName} ${'<'.padEnd(padLength, '-')}`);
 	try {
 		require(testFile);
 	} catch (e) {


### PR DESCRIPTION
- Add 'performance' and 'now' to identifiers and properties to skip
- Dynamically lengthen printed line separating tests
- Add utility to create a "clean" version of scripts
- Fix bug where multiple block statements nested under a single block would be ignored
- Add TP tests for consolidateNestedBlockStatements
- Refactor to apply changes after each function that committed changes