### PR TITLE
Fixed bug in resolveAugmentedFunctionWrappedArrayReplacements

### DIFF
--- a/src/modules/unsafe/resolveAugmentedFunctionWrappedArrayReplacements.js
+++ b/src/modules/unsafe/resolveAugmentedFunctionWrappedArrayReplacements.js
@@ -31,7 +31,7 @@ function resolveAugmentedFunctionWrappedArrayReplacements(arb) {
 						arrRef = ac.declNode.parentNode?.parentNode || ac.declNode.parentNode;
 					}
 				} else if (ac.declNode.parentNode?.init?.type === 'CallExpression') {
-					arrRef = ac.declNode.parentNode.init.callee.declNode.parentNode;
+					arrRef = ac.declNode.parentNode.init.callee?.declNode?.parentNode;
 				}
 				if (arrRef) {
 					const arrRefId = ac.declNode.nodeId;


### PR DESCRIPTION
Fix issue where an array candidate was initiated to a call expression which callee was a member expression - and was not handled correctly