### PR TITLE
Fix left side of assignment local member replacement with literal value

### DIFF
--- a/src/modules/unsafe/resolveMemberExpressionsLocalReferences.js
+++ b/src/modules/unsafe/resolveMemberExpressionsLocalReferences.js
@@ -24,6 +24,7 @@ function resolveMemberExpressionsLocalReferences(arb, candidateFilter = () => tr
 		n.type === 'MemberExpression' &&
 		['Identifier', 'Literal'].includes(n.property.type) &&
 		!skipProperties.includes(n.property?.name || n.property?.value) &&
+		(!(n.parentKey == 'left' && n.parentNode.type === 'AssignmentExpression')) &&
 		candidateFilter(n));
 
 	for (const c of candidates) {


### PR DESCRIPTION
Fix issue where member expression used on the left side of an assignment would get replaced with literal value, breaking the script.