### PR TITLE
Improve augmented array coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,9 +1175,9 @@
       "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
     },
     "node_modules/obfuscation-detector": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/obfuscation-detector/-/obfuscation-detector-1.1.0.tgz",
-      "integrity": "sha512-qDEJWJRfB/puE+B18P8SMFIpda6Eibknoo+OtNA5KA6oIfOkV1878UfxSaMBlkSQH8V8rsv6YviNRsEYIbTujQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/obfuscation-detector/-/obfuscation-detector-1.1.1.tgz",
+      "integrity": "sha512-v54vhiOoF/pgT8JRfmbnWSHbAiAwbO9U+ulR9zEwH9E4lHWbaisX5qVoll4NLsaaEzOOmylNakvdEVhEzntobg==",
       "dependencies": {
         "flast": "^1.0.1"
       }
@@ -1683,15 +1683,15 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "restringer",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "restringer",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "flast": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restringer",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Deobfuscate Javascript with emphasis on reconstructing strings",
   "main": "index.js",
   "bin": {

--- a/src/processors/augmentedArray.js
+++ b/src/processors/augmentedArray.js
@@ -44,7 +44,7 @@ function replaceArrayWithStaticAugmentedVersion(arb) {
 
 	for (const c of candidates) {
 		let targetNode = c;
-		while (targetNode && targetNode.type !== 'ExpressionStatement') {
+		while (targetNode && (targetNode.type !== 'ExpressionStatement' && targetNode.parentNode.type !== 'SequenceExpression')) {
 			targetNode = targetNode?.parentNode;
 		}
 		const relevantArrayIdentifier = c.arguments.find(n => n.type === 'Identifier');

--- a/src/processors/augmentedArray.js
+++ b/src/processors/augmentedArray.js
@@ -54,7 +54,7 @@ function replaceArrayWithStaticAugmentedVersion(arb) {
 		const contextNodes = getDeclarationWithContext(c, true);
 		const context = `${contextNodes.length ? createOrderedSrc(contextNodes) : ''}`;
 		// By adding the name of the array after the context, the un-shuffled array is procured.
-		const src = `${context};\n${targetNode.src}\n${ref};`;
+		const src = `${context};\n${createOrderedSrc([targetNode])}\n${ref};`;
 		const newNode = evalInVm(src);  // The new node will hold the un-shuffled array's assignment
 		if (newNode !== badValue) {
 			arb.markNode(targetNode || c);


### PR DESCRIPTION
Update the obfuscation-detector to v1.1.1 which improves the augmented proxied array function replacements, and complement that coverage in the augmented array processor