### PR TITLE
Add simplifyIfStatements Module and Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "restringer",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "restringer",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "flast": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restringer",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Deobfuscate Javascript with emphasis on reconstructing strings",
   "main": "index.js",
   "bin": {

--- a/src/modules/safe/index.js
+++ b/src/modules/safe/index.js
@@ -25,6 +25,7 @@ module.exports = {
 	resolveRedundantLogicalExpressions: require(__dirname + '/resolveRedundantLogicalExpressions'),
 	separateChainedDeclarators: require(__dirname + '/separateChainedDeclarators'),
 	simplifyCalls: require(__dirname + '/simplifyCalls'),
+	simplifyIfStatements: require(__dirname + '/simplifyIfStatements'),
 	unwrapFunctionShells: require(__dirname + '/unwrapFunctionShells'),
 	unwrapIIFEs: require(__dirname + '/unwrapIIFEs'),
 	unwrapSimpleOperations: require(__dirname + '/unwrapSimpleOperations'),

--- a/src/modules/safe/simplifyIfStatements.js
+++ b/src/modules/safe/simplifyIfStatements.js
@@ -1,0 +1,43 @@
+/**
+ *
+ * @param {Arborist} arb
+ * @param {Function} candidateFilter (optional) a filter to apply on the candidates list
+ * @return {Arborist}
+ */
+function simplifyIfStatements(arb, candidateFilter = () => true) {
+	for (let i = 0; i < arb.ast.length; i++) {
+		const n = arb.ast[i];
+		if (n.type === 'IfStatement' && candidateFilter(n)) {
+			// Empty consequent
+			if (n.consequent.type === 'EmptyStatement' || (n.consequent.type === 'BlockStatement' && !n.consequent.body.length)) {
+				// Populated alternate
+				if (n.alternate && n.alternate.type !== 'EmptyStatement' && !(n.alternate.type === 'BlockStatement' && !n.alternate.body.length)) {
+					// Wrap the test clause in a logical NOT, replace the consequent with the alternate, and remove the now empty alternate.
+					arb.markNode(n, {
+						type: 'IfStatement',
+						test: {
+							type: 'UnaryExpression',
+							operator: '!',
+							prefix: true,
+							argument: n.test,
+						},
+						consequent: n.alternate,
+						alternate: null,
+					});
+				} else arb.markNode(n, {
+					type: 'ExpressionStatement',
+					expression: n.test,
+				}); // Empty alternate
+			} else if (n.alternate && (n.alternate.type === 'EmptyStatement' || (n.alternate.type === 'BlockStatement' && !n.alternate.body.length))) {
+				// Remove the empty alternate clause
+				arb.markNode(n, {
+					...n,
+					alternate: null,
+				});
+			}
+		}
+	}
+	return arb;
+}
+
+module.exports = simplifyIfStatements;

--- a/src/restringer.js
+++ b/src/restringer.js
@@ -33,6 +33,7 @@ const {
 		resolveProxyReferences,
 		rearrangeSequences,
 		simplifyCalls,
+		simplifyIfStatements,
 		rearrangeSwitches,
 		unwrapIIFEs,
 		unwrapSimpleOperations,
@@ -123,6 +124,7 @@ class REstringer {
 			simplifyCalls,
 			unwrapFunctionShells,
 			unwrapIIFEs,
+			simplifyIfStatements,
 		];
 	}
 

--- a/tests/modules-tests.js
+++ b/tests/modules-tests.js
@@ -537,6 +537,55 @@ function xor(b, c) {
 		source: `func1.apply(this, [arg1, arg2]); func2.call(this, arg1, arg2);`,
 		expected: `func1(arg1, arg2);\nfunc2(arg1, arg2);`,
 	},
+	{
+		enabled: true,
+		name: 'simplifyIfStatements - TP-1 (empty blocks)',
+		func: __dirname + '/../src/modules/safe/simplifyIfStatements',
+		source: `if (J) {} else {}`,
+		expected: `J;`,
+	},
+	{
+		enabled: true,
+		name: 'simplifyIfStatements - TP-2 (empty block, empty alternate statement)',
+		func: __dirname + '/../src/modules/safe/simplifyIfStatements',
+		source: `if (J) {} else;`,
+		expected: `J;`,
+	},
+	{
+		enabled: true,
+		name: 'simplifyIfStatements - TP-3 (empty block, populated alternate expression)',
+		func: __dirname + '/../src/modules/safe/simplifyIfStatements',
+		source: `if (J) {} else J();`,
+		expected: `if (!J)\n  J();`,
+	},
+	{
+		enabled: true,
+		name: 'simplifyIfStatements - TP-4 (empty block, populated alternate block)',
+		func: __dirname + '/../src/modules/safe/simplifyIfStatements',
+		source: `if (J) {} else {J()}`,
+		expected: `if (!J) {\n  J();\n}`,
+	},
+	{
+		enabled: true,
+		name: 'simplifyIfStatements - TP-5 (empty statements)',
+		func: __dirname + '/../src/modules/safe/simplifyIfStatements',
+		source: `if (J); else;`,
+		expected: `J;`,
+	},
+	{
+		enabled: true,
+		name: 'simplifyIfStatements - TP-6 (empty statement, no alternate)',
+		func: __dirname + '/../src/modules/safe/simplifyIfStatements',
+		source: `if (J);`,
+		expected: `J;`,
+	},
+	{
+		enabled: true,
+		name: 'simplifyIfStatements - TP-7 (empty block, no alternate)',
+		func: __dirname + '/../src/modules/safe/simplifyIfStatements',
+		source: `if (J) {}`,
+		expected: `J;`,
+	},
 
 	// Unsafe
 	{


### PR DESCRIPTION
Solves an issue mentioned in #90 
- Remove redundant clauses from the if statement
- Reverse logic when the consequent clause is empty and the alternate clause is not
- Replace statement with test expression if all clauses are empty