### PR TITLE
Externalize Deob Methods on REstringer Instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "restringer",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "restringer",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "flast": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restringer",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Deobfuscate Javascript with emphasis on reconstructing strings",
   "main": "index.js",
   "bin": {

--- a/src/restringer.js
+++ b/src/restringer.js
@@ -34,6 +34,7 @@ class REstringer {
 		this._postprocessors = [];
 		this.logger = logger;
 		this.logger.setLogLevel(logger.logLevels.LOG);    // Default log level
+		this.detectObfuscationType = true;
 		// Deobfuscation methods that don't use eval
 		this.safeMethods = [
 			safe.rearrangeSequences,
@@ -125,7 +126,7 @@ class REstringer {
 	 * @return {boolean} true if the script was modified during deobfuscation; false otherwise.
 	 */
 	deobfuscate(clean = false) {
-		this.determineObfuscationType();
+		if (this.detectObfuscationType) this.determineObfuscationType();
 		this._runProcessors(this._preprocessors);
 		this._loopSafeAndUnsafeDeobfuscationMethods();
 		this._runProcessors(this._postprocessors);


### PR DESCRIPTION
Solving #88 
- Externalize safe and unsafe methods on the REstringer instance
- Allow automatic detection of obfuscation type to be disabled on the REstringer instance