### PR TITLE
Fix UnwrapIIFEs Missing Filter Check

### DIFF
--- a/src/modules/safe/unwrapIIFEs.js
+++ b/src/modules/safe/unwrapIIFEs.js
@@ -37,7 +37,7 @@ function unwrapIIFEs(arb, candidateFilter = () => true) {
 					targetChild = targetNode;
 					targetNode = targetNode.parentNode;
 				}
-				if (!targetNode || !targetNode.body) targetNode = n;
+				if (!targetNode?.body?.filter) targetNode = n;
 				else {
 					// Place the wrapped code instead of the wrapper node
 					replacementNode = {


### PR DESCRIPTION
Fix issue where targetNode.body.filter is called when targetNode.body is not an array