### PR TITLE
Use nodeId for visitNodes.

### DIFF
--- a/src/modules/utils/getDeclarationWithContext.js
+++ b/src/modules/utils/getDeclarationWithContext.js
@@ -165,7 +165,7 @@ export function getDeclarationWithContext(originNode, excludeOriginNode = false)
 		while (stack.length) {
 			const node = stack.shift();
 			if (visitedNodes.has(node.nodeId)) continue;
-			visitedNodes.add(node);
+			visitedNodes.add(node.nodeId);
 			// Do not collect any context if one of the relevant nodes is marked to be replaced or deleted
 			if (node.isMarked || doesDescendantMatchCondition(node, n => n.isMarked)) {
 				collected.length = 0;

--- a/src/modules/utils/getDeclarationWithContext.js
+++ b/src/modules/utils/getDeclarationWithContext.js
@@ -138,7 +138,7 @@ export function getDeclarationWithContext(originNode, excludeOriginNode = false)
 	const stack = [originNode];   // The working stack for nodes to be reviewed
 	/** @type {ASTNode[]} */
 	const collected = [];         // These will be our context
-	/** @type {Set<ASTNode>} */
+	/** @type {Set<number>} */
 	const visitedNodes = new Set();  // Track visited nodes to prevent infinite loops
 	/** @type {number[][]} */
 	const collectedRanges = [];   // Prevent collecting overlapping nodes
@@ -149,7 +149,7 @@ export function getDeclarationWithContext(originNode, excludeOriginNode = false)
 	 */
 	function addToStack(node) {
 		if (!node || 
-			visitedNodes.has(node) ||
+			visitedNodes.has(node.nodeId) ||
 			stack.includes(node) ||
 			SKIP_TRAVERSAL_TYPES.includes(node.type)) {
 			return;
@@ -164,7 +164,7 @@ export function getDeclarationWithContext(originNode, excludeOriginNode = false)
 	if (!cached) {
 		while (stack.length) {
 			const node = stack.shift();
-			if (visitedNodes.has(node)) continue;
+			if (visitedNodes.has(node.nodeId)) continue;
 			visitedNodes.add(node);
 			// Do not collect any context if one of the relevant nodes is marked to be replaced or deleted
 			if (node.isMarked || doesDescendantMatchCondition(node, n => n.isMarked)) {
@@ -223,7 +223,7 @@ export function getDeclarationWithContext(originNode, excludeOriginNode = false)
 
 			for (let i = 0; i < targetNodes.length; i++) {
 				const targetNode = targetNodes[i];
-				if (!visitedNodes.has(targetNode)) stack.push(targetNode);
+				if (!visitedNodes.has(node.nodeId)) stack.push(targetNode);
 				// noinspection JSUnresolvedVariable
 				if (targetNode === targetNode.scope.block) {
 					// Collect out-of-scope variables used inside the scope

--- a/src/modules/utils/getDeclarationWithContext.js
+++ b/src/modules/utils/getDeclarationWithContext.js
@@ -223,7 +223,7 @@ export function getDeclarationWithContext(originNode, excludeOriginNode = false)
 
 			for (let i = 0; i < targetNodes.length; i++) {
 				const targetNode = targetNodes[i];
-				if (!visitedNodes.has(node.nodeId)) stack.push(targetNode);
+				if (!visitedNodes.has(targetNode.nodeId)) stack.push(targetNode);
 				// noinspection JSUnresolvedVariable
 				if (targetNode === targetNode.scope.block) {
 					// Collect out-of-scope variables used inside the scope


### PR DESCRIPTION
getDeclarationWithContext crashes with an OOM error if the origin node is too large.  Using the unique nodeId instead of a full copy of the node reduced the memory footprint enough to not cause a crash.

I also considered using an md5 hash of the node, but does not seem worth it unless we have concerns about the uniqueness of nodeId.

Tested against large (1.0mib) mahjong soul code.js, see https://github.com/Avenshy/AutoLiqi/releases
(Still crashes against the original file, but passed a truncated version. The full version crashes earlier.)

Also first time contributing so let me know if there's a different process preferred for PRs.
I still have a second OOM I'm chasing down in flast, so probably expect a PR there as well.